### PR TITLE
feat: remove global postBuild patch

### DIFF
--- a/kubernetes/apps/actions-runner-system/actions-runner-controller/ks.yaml
+++ b/kubernetes/apps/actions-runner-system/actions-runner-controller/ks.yaml
@@ -14,6 +14,10 @@ spec:
       namespace: external-secrets
   interval: 30m
   path: ./kubernetes/apps/actions-runner-system/actions-runner-controller/app
+  postBuild:
+    substituteFrom:
+      - name: cluster-secrets
+        kind: Secret
   prune: true
   sourceRef:
     kind: GitRepository
@@ -35,6 +39,10 @@ spec:
       app.kubernetes.io/name: *app
   interval: 30m
   path: ./kubernetes/apps/actions-runner-system/actions-runner-controller/runners
+  postBuild:
+    substituteFrom:
+      - name: cluster-secrets
+        kind: Secret
   prune: true
   sourceRef:
     kind: GitRepository

--- a/kubernetes/apps/cert-manager/cert-manager/ks.yaml
+++ b/kubernetes/apps/cert-manager/cert-manager/ks.yaml
@@ -21,6 +21,10 @@ spec:
       current: status.conditions.filter(e, e.type == 'Ready').all(e, e.status == 'True')
   interval: 1h
   path: ./kubernetes/apps/cert-manager/cert-manager/app
+  postBuild:
+    substituteFrom:
+      - name: cluster-secrets
+        kind: Secret
   prune: true
   retryInterval: 2m
   sourceRef:

--- a/kubernetes/apps/default/echo-server/ks.yaml
+++ b/kubernetes/apps/default/echo-server/ks.yaml
@@ -16,6 +16,9 @@ spec:
   postBuild:
     substitute:
       APP: *app
+    substituteFrom:
+      - name: cluster-secrets
+        kind: Secret
   prune: true
   retryInterval: 2m
   sourceRef:

--- a/kubernetes/apps/default/flame/ks.yaml
+++ b/kubernetes/apps/default/flame/ks.yaml
@@ -16,6 +16,9 @@ spec:
   postBuild:
     substitute:
       APP: *app
+    substituteFrom:
+      - name: cluster-secrets
+        kind: Secret
   prune: true
   retryInterval: 2m
   sourceRef:

--- a/kubernetes/apps/external-secrets/external-secrets/ks.yaml
+++ b/kubernetes/apps/external-secrets/external-secrets/ks.yaml
@@ -11,6 +11,10 @@ spec:
       app.kubernetes.io/name: *app
   interval: 1h
   path: ./kubernetes/apps/external-secrets/external-secrets/app
+  postBuild:
+    substituteFrom:
+      - name: cluster-secrets
+        kind: Secret
   prune: true
   retryInterval: 2m
   sourceRef:

--- a/kubernetes/apps/external-secrets/onepassword/ks.yaml
+++ b/kubernetes/apps/external-secrets/onepassword/ks.yaml
@@ -11,6 +11,10 @@ spec:
       app.kubernetes.io/name: *app
   interval: 1h
   path: ./kubernetes/apps/external-secrets/onepassword/app
+  postBuild:
+    substituteFrom:
+      - name: cluster-secrets
+        kind: Secret
   prune: true
   retryInterval: 2m
   sourceRef:
@@ -36,6 +40,10 @@ spec:
       namespace: external-secrets
   interval: 1h
   path: ./kubernetes/apps/external-secrets/onepassword/store
+  postBuild:
+    substituteFrom:
+      - name: cluster-secrets
+        kind: Secret
   prune: true
   retryInterval: 2m
   sourceRef:

--- a/kubernetes/apps/flux-system/flux-instance/ks.yaml
+++ b/kubernetes/apps/flux-system/flux-instance/ks.yaml
@@ -14,6 +14,10 @@ spec:
       namespace: *namespace
   interval: 1h
   path: ./kubernetes/apps/flux-system/flux-instance/app
+  postBuild:
+    substituteFrom:
+      - name: cluster-secrets
+        kind: Secret
   prune: true
   retryInterval: 2m
   sourceRef:

--- a/kubernetes/apps/flux-system/flux-operator/ks.yaml
+++ b/kubernetes/apps/flux-system/flux-operator/ks.yaml
@@ -16,6 +16,10 @@ spec:
       namespace: *namespace
   interval: 1h
   path: ./kubernetes/apps/flux-system/flux-operator/app
+  postBuild:
+    substituteFrom:
+      - name: cluster-secrets
+        kind: Secret
   prune: true
   retryInterval: 2m
   sourceRef:

--- a/kubernetes/apps/kube-system/cilium/ks.yaml
+++ b/kubernetes/apps/kube-system/cilium/ks.yaml
@@ -11,6 +11,10 @@ spec:
       app.kubernetes.io/name: *app
   interval: 1h
   path: ./kubernetes/apps/kube-system/cilium/app
+  postBuild:
+    substituteFrom:
+      - name: cluster-secrets
+        kind: Secret
   prune: true
   retryInterval: 2m
   sourceRef:
@@ -36,6 +40,10 @@ spec:
       namespace: cert-manager
   interval: 1h
   path: ./kubernetes/apps/kube-system/cilium/gateway
+  postBuild:
+    substituteFrom:
+      - name: cluster-secrets
+        kind: Secret
   prune: true
   sourceRef:
     kind: GitRepository

--- a/kubernetes/apps/kube-system/coredns/ks.yaml
+++ b/kubernetes/apps/kube-system/coredns/ks.yaml
@@ -11,6 +11,10 @@ spec:
       app.kubernetes.io/name: *app
   interval: 1h
   path: ./kubernetes/apps/kube-system/coredns/app
+  postBuild:
+    substituteFrom:
+      - name: cluster-secrets
+        kind: Secret
   prune: true
   retryInterval: 2m
   sourceRef:

--- a/kubernetes/apps/kube-system/metrics-server/ks.yaml
+++ b/kubernetes/apps/kube-system/metrics-server/ks.yaml
@@ -11,6 +11,10 @@ spec:
       app.kubernetes.io/name: *app
   interval: 1h
   path: ./kubernetes/apps/kube-system/metrics-server/app
+  postBuild:
+    substituteFrom:
+      - name: cluster-secrets
+        kind: Secret
   prune: true
   retryInterval: 2m
   sourceRef:

--- a/kubernetes/apps/kube-system/reloader/ks.yaml
+++ b/kubernetes/apps/kube-system/reloader/ks.yaml
@@ -11,6 +11,10 @@ spec:
       app.kubernetes.io/name: *app
   interval: 1h
   path: ./kubernetes/apps/kube-system/reloader/app
+  postBuild:
+    substituteFrom:
+      - name: cluster-secrets
+        kind: Secret
   prune: true
   retryInterval: 2m
   sourceRef:

--- a/kubernetes/apps/kube-system/spegel/ks.yaml
+++ b/kubernetes/apps/kube-system/spegel/ks.yaml
@@ -11,6 +11,10 @@ spec:
       app.kubernetes.io/name: *app
   interval: 1h
   path: ./kubernetes/apps/kube-system/spegel/app
+  postBuild:
+    substituteFrom:
+      - name: cluster-secrets
+        kind: Secret
   prune: true
   retryInterval: 2m
   sourceRef:

--- a/kubernetes/apps/network/cloudflare-dns/app/helmrelease.yaml
+++ b/kubernetes/apps/network/cloudflare-dns/app/helmrelease.yaml
@@ -15,12 +15,10 @@ spec:
         name: cloudflare-dns
         namespace: network
   install:
-    crds: CreateReplace
     remediation:
       retries: 3
   upgrade:
     cleanupOnFail: true
-    crds: CreateReplace
     remediation:
       strategy: rollback
       retries: 3

--- a/kubernetes/apps/network/cloudflare-dns/ks.yaml
+++ b/kubernetes/apps/network/cloudflare-dns/ks.yaml
@@ -19,6 +19,10 @@ spec:
       name: dnsendpoints.externaldns.k8s.io
   interval: 1h
   path: ./kubernetes/apps/network/cloudflare-dns/app
+  postBuild:
+    substituteFrom:
+      - name: cluster-secrets
+        kind: Secret
   prune: true
   retryInterval: 2m
   sourceRef:

--- a/kubernetes/apps/network/cloudflare-tunnel/ks.yaml
+++ b/kubernetes/apps/network/cloudflare-tunnel/ks.yaml
@@ -14,6 +14,10 @@ spec:
       namespace: *namespace
   interval: 1h
   path: ./kubernetes/apps/network/cloudflare-tunnel/app
+  postBuild:
+    substituteFrom:
+      - name: cluster-secrets
+        kind: Secret
   prune: true
   retryInterval: 2m
   sourceRef:

--- a/kubernetes/apps/network/unifi-dns/ks.yaml
+++ b/kubernetes/apps/network/unifi-dns/ks.yaml
@@ -14,6 +14,10 @@ spec:
       namespace: external-secrets
   interval: 1h
   path: ./kubernetes/apps/network/unifi-dns/app
+  postBuild:
+    substituteFrom:
+      - name: cluster-secrets
+        kind: Secret
   prune: true
   retryInterval: 2m
   sourceRef:

--- a/kubernetes/apps/observability/gatus/ks.yaml
+++ b/kubernetes/apps/observability/gatus/ks.yaml
@@ -20,6 +20,9 @@ spec:
     substitute:
       APP: *app
       GATUS_SUBDOMAIN: status
+    substituteFrom:
+      - name: cluster-secrets
+        kind: Secret
   prune: true
   retryInterval: 2m
   sourceRef:

--- a/kubernetes/apps/observability/kube-prometheus-stack/ks.yaml
+++ b/kubernetes/apps/observability/kube-prometheus-stack/ks.yaml
@@ -22,6 +22,9 @@ spec:
     substitute:
       APP: kube-prometheus-stack
       GATUS_SUBDOMAIN: prometheus
+    substituteFrom:
+      - name: cluster-secrets
+        kind: Secret
   prune: true
   retryInterval: 2m
   sourceRef:

--- a/kubernetes/apps/openebs-system/openebs/ks.yaml
+++ b/kubernetes/apps/openebs-system/openebs/ks.yaml
@@ -11,6 +11,10 @@ spec:
       app.kubernetes.io/name: *app
   interval: 30m
   path: ./kubernetes/apps/openebs-system/openebs/app
+  postBuild:
+    substituteFrom:
+      - name: cluster-secrets
+        kind: Secret
   prune: true
   sourceRef:
     kind: GitRepository

--- a/kubernetes/apps/volsync-system/snapshot-controller/ks.yaml
+++ b/kubernetes/apps/volsync-system/snapshot-controller/ks.yaml
@@ -11,6 +11,10 @@ spec:
       app.kubernetes.io/name: *app
   interval: 30m
   path: ./kubernetes/apps/volsync-system/snapshot-controller/app
+  postBuild:
+    substituteFrom:
+      - name: cluster-secrets
+        kind: Secret
   prune: true
   sourceRef:
     kind: GitRepository

--- a/kubernetes/flux/cluster/ks.yaml
+++ b/kubernetes/flux/cluster/ks.yaml
@@ -56,6 +56,10 @@ spec:
             provider: sops
             secretRef:
               name: sops-age
+          postBuild:
+            substituteFrom:
+              - name: cluster-secrets
+                kind: Secret
       target:
         group: kustomize.toolkit.fluxcd.io
         kind: Kustomization

--- a/kubernetes/flux/cluster/ks.yaml
+++ b/kubernetes/flux/cluster/ks.yaml
@@ -39,14 +39,6 @@ spec:
   interval: 1h
   path: ./kubernetes/apps
   prune: true
-  postBuild:
-    substituteFrom:
-      - name: cluster-settings
-        kind: ConfigMap
-        optional: true
-      - name: cluster-secrets
-        kind: Secret
-        optional: false
   retryInterval: 2m
   sourceRef:
     kind: GitRepository
@@ -64,15 +56,6 @@ spec:
             provider: sops
             secretRef:
               name: sops-age
-          postBuild:
-            substituteFrom:
-              - name: cluster-settings
-                kind: ConfigMap
-                optional: true
-              - name: cluster-secrets
-                kind: Secret
-                optional: false
       target:
         group: kustomize.toolkit.fluxcd.io
         kind: Kustomization
-        labelSelector: substitution.flux.home.arpa/disabled notin (true)

--- a/kubernetes/flux/cluster/ks.yaml
+++ b/kubernetes/flux/cluster/ks.yaml
@@ -56,10 +56,6 @@ spec:
             provider: sops
             secretRef:
               name: sops-age
-          postBuild:
-            substituteFrom:
-              - name: cluster-secrets
-                kind: Secret
       target:
         group: kustomize.toolkit.fluxcd.io
         kind: Kustomization

--- a/scripts/bootstrap-apps.sh
+++ b/scripts/bootstrap-apps.sh
@@ -93,6 +93,8 @@ function apply_crds() {
         https://github.com/kubernetes-sigs/gateway-api/releases/download/v1.2.1/experimental-install.yaml
         # renovate: datasource=github-releases depName=prometheus-operator/prometheus-operator
         https://github.com/prometheus-operator/prometheus-operator/releases/download/v0.81.0/stripped-down-crds.yaml
+        # renovate: datasource=github-releases depName=kubernetes-sigs/external-dns
+        https://raw.githubusercontent.com/kubernetes-sigs/external-dns/refs/tags/v0.16.0/docs/sources/crd/crd-manifest.yaml
     )
 
     for crd in "${crds[@]}"; do


### PR DESCRIPTION
- patch ended up interfering with postBuilds set on individual app ks
- Install external-dns endpoint CRD on bootstrap (this never changes and removes some dependsOn)
- ref: https://github.com/onedr0p/cluster-template/commit/d1d659652cc431f2da8fbd6fc8ecf76773fa2a2c