### PR TITLE
chore: use gateway-name filter for external-dns 

### DIFF
--- a/kubernetes/apps/kube-system/cilium/gateway/external.yaml
+++ b/kubernetes/apps/kube-system/cilium/gateway/external.yaml
@@ -6,8 +6,6 @@ metadata:
   name: external
   annotations:
     external-dns.alpha.kubernetes.io/target: &hostname external.igloo.sh
-  labels:
-    gateway: external
 spec:
   gatewayClassName: cilium
   addresses:

--- a/kubernetes/apps/kube-system/cilium/gateway/internal.yaml
+++ b/kubernetes/apps/kube-system/cilium/gateway/internal.yaml
@@ -6,8 +6,6 @@ metadata:
   name: internal
   annotations:
     external-dns.alpha.kubernetes.io/target: &hostname internal.igloo.sh
-  labels:
-    gateway: internal
 spec:
   gatewayClassName: cilium
   addresses:

--- a/kubernetes/apps/network/cloudflare-dns/app/helmrelease.yaml
+++ b/kubernetes/apps/network/cloudflare-dns/app/helmrelease.yaml
@@ -24,9 +24,9 @@ spec:
       retries: 3
   values:
     fullnameOverride: *app
-    image: # TODO: https://github.com/kubernetes-sigs/external-dns/pull/4943
-      repository: ghcr.io/buroa/external-dns
-      tag: 631b84da
+    image: # TODO: Remove this block when new chart version is released
+      repository: registry.k8s.io/external-dns/external-dns
+      tag: v0.16.1
     provider: cloudflare
     env:
       - name: &name CF_API_TOKEN
@@ -44,7 +44,7 @@ spec:
       - --cloudflare-proxied
       - --crd-source-apiversion=externaldns.k8s.io/v1alpha1
       - --crd-source-kind=DNSEndpoint
-      - --gateway-label-filter=gateway==external
+      - --gateway-name=external
       - --zone-id-filter=$(CF_ZONE_ID)
     policy: sync
     sources: ["crd", "gateway-httproute"]

--- a/kubernetes/apps/network/unifi-dns/app/helmrelease.yaml
+++ b/kubernetes/apps/network/unifi-dns/app/helmrelease.yaml
@@ -24,9 +24,9 @@ spec:
       retries: 3
   values:
     fullnameOverride: *app
-    image: # TODO: https://github.com/kubernetes-sigs/external-dns/pull/4943
-      repository: ghcr.io/buroa/external-dns
-      tag: 631b84da
+    image: # TODO: Remove this block when new chart version is released
+      repository: registry.k8s.io/external-dns/external-dns
+      tag: v0.16.1
     provider:
       name: webhook
       webhook:


### PR DESCRIPTION
- also upgrade to an image that allows it
- https://github.com/onedr0p/home-ops/commit/e1e776fd4bf04d1d2454a0bfe8a66b4ee67669d6