### PR TITLE
feat: add jellyfin dashboard to grafana

### DIFF
--- a/kubernetes/apps/observability/grafana/app/externalsecret.yaml
+++ b/kubernetes/apps/observability/grafana/app/externalsecret.yaml
@@ -14,7 +14,7 @@ spec:
       data:
         admin-user: "{{ .GRAFANA_ADMIN_USERNAME }}"
         admin-password: "{{ .GRAFANA_ADMIN_PASSWORD }}"
-        jellyfin-api-key: "{{ JELLYFIN_API_KEY }}"
+        jellyfin-api-key: "{{ .JELLYFIN_API_KEY }}"
   dataFrom:
     - extract:
         key: grafana

--- a/kubernetes/apps/observability/grafana/app/externalsecret.yaml
+++ b/kubernetes/apps/observability/grafana/app/externalsecret.yaml
@@ -14,6 +14,9 @@ spec:
       data:
         admin-user: "{{ .GRAFANA_ADMIN_USERNAME }}"
         admin-password: "{{ .GRAFANA_ADMIN_PASSWORD }}"
+        jellyfin-api-key: "{{ JELLYFIN_API_KEY }}"
   dataFrom:
     - extract:
         key: grafana
+    - extract:
+        key: jellyfin

--- a/kubernetes/apps/observability/grafana/app/externalsecret.yaml
+++ b/kubernetes/apps/observability/grafana/app/externalsecret.yaml
@@ -15,6 +15,7 @@ spec:
         admin-user: "{{ .GRAFANA_ADMIN_USERNAME }}"
         admin-password: "{{ .GRAFANA_ADMIN_PASSWORD }}"
         jellyfin-api-key: "{{ JELLYFIN_API_KEY }}"
+        JELLYFIN_API_KEY: "{{ JELLYFIN_API_KEY }}"
   dataFrom:
     - extract:
         key: grafana

--- a/kubernetes/apps/observability/grafana/app/externalsecret.yaml
+++ b/kubernetes/apps/observability/grafana/app/externalsecret.yaml
@@ -14,7 +14,6 @@ spec:
       data:
         admin-user: "{{ .GRAFANA_ADMIN_USERNAME }}"
         admin-password: "{{ .GRAFANA_ADMIN_PASSWORD }}"
-        jellyfin-api-key: "{{ JELLYFIN_API_KEY }}"
         JELLYFIN_API_KEY: "{{ JELLYFIN_API_KEY }}"
   dataFrom:
     - extract:

--- a/kubernetes/apps/observability/grafana/app/externalsecret.yaml
+++ b/kubernetes/apps/observability/grafana/app/externalsecret.yaml
@@ -14,7 +14,7 @@ spec:
       data:
         admin-user: "{{ .GRAFANA_ADMIN_USERNAME }}"
         admin-password: "{{ .GRAFANA_ADMIN_PASSWORD }}"
-        JELLYFIN_API_KEY: "{{ JELLYFIN_API_KEY }}"
+        jellyfin-api-key: "{{ JELLYFIN_API_KEY }}"
   dataFrom:
     - extract:
         key: grafana

--- a/kubernetes/apps/observability/grafana/app/helm/values.yaml
+++ b/kubernetes/apps/observability/grafana/app/helm/values.yaml
@@ -60,7 +60,7 @@ datasources:
           httpMethod: GET
           timeout: 30
         secureJsonData:
-          apiKey: ${JELLYFIN_API_TOKEN}
+          apiKey: ${JELLYFIN_API_KEY}
 dashboardProviders:
   dashboardproviders.yaml:
     apiVersion: 1

--- a/kubernetes/apps/observability/grafana/app/helm/values.yaml
+++ b/kubernetes/apps/observability/grafana/app/helm/values.yaml
@@ -59,7 +59,7 @@ datasources:
         type: marcusolsson-json-datasource
         uid: jellyfin
         access: proxy
-        url: http://jellyfin.servarr.svc.cluster.local:8096
+        url: http://jellyfin.servarr.svc.cluster.local:8096/Sessions
         jsonData:
           httpMethod: GET
           timeout: 30

--- a/kubernetes/apps/observability/grafana/app/helm/values.yaml
+++ b/kubernetes/apps/observability/grafana/app/helm/values.yaml
@@ -9,7 +9,11 @@ env:
   GF_PLUGINS_ALLOW_LOADING_UNSIGNED_PLUGINS: natel-discrete-panel,pr0ps-trackmap-panel,panodata-map-panel
   GF_SECURITY_ANGULAR_SUPPORT_ENABLED: true
   GF_SERVER_ROOT_URL: https://grafana.igloo.sh
-envFromSecret: "grafana-admin-secret"
+envValueFrom:
+  JELLYFIN_API_KEY:
+    secretKeyRef:
+      name: grafana-admin-secret
+      key: jellyfin-api-key
 grafana.ini:
   analytics:
     check_for_updates: false

--- a/kubernetes/apps/observability/grafana/app/helm/values.yaml
+++ b/kubernetes/apps/observability/grafana/app/helm/values.yaml
@@ -12,7 +12,7 @@ env:
   JELLYFIN_API_TOKEN:
     valueFrom:
       secretKeyRef:
-        name: grafana-admin
+        name: grafana-admin-secret
         key: jellyfin-api-key
 grafana.ini:
   analytics:

--- a/kubernetes/apps/observability/grafana/app/helm/values.yaml
+++ b/kubernetes/apps/observability/grafana/app/helm/values.yaml
@@ -9,11 +9,7 @@ env:
   GF_PLUGINS_ALLOW_LOADING_UNSIGNED_PLUGINS: natel-discrete-panel,pr0ps-trackmap-panel,panodata-map-panel
   GF_SECURITY_ANGULAR_SUPPORT_ENABLED: true
   GF_SERVER_ROOT_URL: https://grafana.igloo.sh
-  JELLYFIN_API_TOKEN:
-    valueFrom:
-      secretKeyRef:
-        name: grafana-admin-secret
-        key: jellyfin-api-key
+envFromSecret: "grafana-admin-secret"
 grafana.ini:
   analytics:
     check_for_updates: false

--- a/kubernetes/apps/observability/grafana/app/helm/values.yaml
+++ b/kubernetes/apps/observability/grafana/app/helm/values.yaml
@@ -9,6 +9,11 @@ env:
   GF_PLUGINS_ALLOW_LOADING_UNSIGNED_PLUGINS: natel-discrete-panel,pr0ps-trackmap-panel,panodata-map-panel
   GF_SECURITY_ANGULAR_SUPPORT_ENABLED: true
   GF_SERVER_ROOT_URL: https://grafana.igloo.sh
+  JELLYFIN_API_TOKEN:
+    valueFrom:
+      secretKeyRef:
+        name: grafana-admin
+        key: jellyfin-api-key
 grafana.ini:
   analytics:
     check_for_updates: false
@@ -28,6 +33,7 @@ datasources:
       - { name: Alertmanager, orgId: 1 }
       - { name: Loki, orgId: 1 }
       - { name: Prometheus, orgId: 1 }
+      - { name: Jellyfin, orgId: 1 }
     datasources:
       - name: Prometheus
         type: prometheus
@@ -49,6 +55,16 @@ datasources:
         url: http://alertmanager-operated.observability.svc.cluster.local:9093
         jsonData:
           implementation: prometheus
+      - name: Jellyfin
+        type: marcusolsson-json-datasource
+        uid: jellyfin
+        access: proxy
+        url: http://jellyfin.servarr.svc.cluster.local:8096
+        jsonData:
+          httpMethod: GET
+          timeout: 30
+        secureJsonData:
+          apiKey: ${JELLYFIN_API_TOKEN}
 dashboardProviders:
   dashboardproviders.yaml:
     apiVersion: 1
@@ -94,6 +110,10 @@ dashboards:
       gnetId: 15038
       revision: 3
       datasource: Prometheus
+    jellyfin-sessions:
+      # renovate: depName="Jellyfin"
+      url: https://gist.githubusercontent.com/dfsnow/aad4ec99afb413968c49efb03bdb1ab9/raw/33b8d1652bdecf72ca6b9fc24fe14a41717816cd/state-timeline-grafana-panel.json
+      datasource: Jellyfin
     kubernetes-api-server:
       # renovate: depName="Kubernetes / System / API Server"
       gnetId: 15761
@@ -200,6 +220,7 @@ plugins:
   - grafana-clock-panel
   - grafana-piechart-panel
   - grafana-worldmap-panel
+  - marcusolsson-json-datasource
   - natel-discrete-panel
   - pr0ps-trackmap-panel
   - vonage-status-panel

--- a/kubernetes/apps/servarr/unpackerr/app/scrapeconfig.yaml
+++ b/kubernetes/apps/servarr/unpackerr/app/scrapeconfig.yaml
@@ -10,3 +10,5 @@ spec:
   staticConfigs:
     - targets:
         - unpackerr.servarr.svc.cluster.local:5656
+        - radarr.servarr.svc.cluster.local:7878
+        - sonarr.servarr.svc.cluster.local:8989


### PR DESCRIPTION
- config(unpackerr): add scrapeConfig

Refs:
- https://grafana.com/grafana/dashboards/18817-unpackerr/
- https://gist.github.com/dfsnow/aad4ec99afb413968c49efb03bdb1ab9
- https://prometheus-operator.dev/docs/developer/scrapeconfig/