### PR TITLE
feat: add gatus heartbeat

### DIFF
--- a/kubernetes/apps/observability/gatus/app/externalsecret.yaml
+++ b/kubernetes/apps/observability/gatus/app/externalsecret.yaml
@@ -14,6 +14,7 @@ spec:
       data:
         PUSHOVER_TOKEN: "{{ .GATUS_PUSHOVER_TOKEN }}"
         PUSHOVER_USER_KEY: "{{ .PUSHOVER_USER_KEY }}"
+        WATCHDOG_HEARTBEAT_TOKEN: "{{ .GATUS_WATCHDOG_HEARTBEAT_TOKEN }}"
   dataFrom:
     - extract:
         key: gatus

--- a/kubernetes/apps/observability/gatus/app/resources/config.yaml
+++ b/kubernetes/apps/observability/gatus/app/resources/config.yaml
@@ -37,3 +37,14 @@ endpoints:
       - "[STATUS] == 404"
     alerts:
       - type: pushover
+external-endpoints:
+  - name: alertmanager-watchdog
+    group: guarded
+    token: ${WATCHDOG_HEARTBEAT_TOKEN}
+    heartbeat:
+      interval: 30m
+    alerts:
+      - type: pushover
+        description: "AlertManager watchdog heartbeat failed - alerting pipeline may be down"
+        failure-threshold: 1
+        success-threshold: 1

--- a/kubernetes/apps/observability/gatus/app/resources/config.yaml
+++ b/kubernetes/apps/observability/gatus/app/resources/config.yaml
@@ -39,7 +39,7 @@ endpoints:
       - type: pushover
 external-endpoints:
   - name: alertmanager-watchdog
-    group: guarded
+    group: external
     token: ${WATCHDOG_HEARTBEAT_TOKEN}
     heartbeat:
       interval: 30m

--- a/kubernetes/apps/observability/kube-prometheus-stack/app/alertmanagerconfig.yaml
+++ b/kubernetes/apps/observability/kube-prometheus-stack/app/alertmanagerconfig.yaml
@@ -17,6 +17,11 @@ spec:
           - name: alertname
             value: InfoInhibitor
             matchType: =
+      - receiver: gatus-watchdog-heartbeat
+        matchers:
+          - name: alertname
+            value: Watchdog
+            matchType: =
       - receiver: pushover
         matchers:
           - name: severity
@@ -34,6 +39,16 @@ spec:
           matchType: =
   receivers:
     - name: "null"
+    - name: gatus-watchdog-heartbeat
+      webhookConfigs:
+        - url: http://gatus.observability.svc.cluster.local/api/v1/endpoints/alertmanager-watchdog/external
+          httpConfig:
+            authorization:
+              type: Bearer
+              credentials:
+                name: &secret alertmanager-secret
+                key: GATUS_WATCHDOG_HEARTBEAT_TOKEN
+          sendResolved: false
     - name: pushover
       pushoverConfigs:
         - html: true
@@ -65,7 +80,7 @@ spec:
             {{ .CommonLabels.alertname }}
           ttl: 86400s
           token:
-            name: &secret alertmanager-secret
+            name: *secret
             key: ALERTMANAGER_PUSHOVER_TOKEN
           userKey:
             name: *secret

--- a/kubernetes/apps/observability/kube-prometheus-stack/app/externalsecret.yaml
+++ b/kubernetes/apps/observability/kube-prometheus-stack/app/externalsecret.yaml
@@ -15,8 +15,11 @@ spec:
       data:
         ALERTMANAGER_PUSHOVER_TOKEN: "{{ .ALERTMANAGER_PUSHOVER_TOKEN }}"
         PUSHOVER_USER_KEY: "{{ .PUSHOVER_USER_KEY }}"
+        GATUS_WATCHDOG_HEARTBEAT_TOKEN: "{{ .GATUS_WATCHDOG_HEARTBEAT_TOKEN }}"
   dataFrom:
     - extract:
         key: pushover
     - extract:
         key: alertmanager
+    - extract:
+        key: gatus


### PR DESCRIPTION
- https://github.com/TwiN/gatus/blob/master/README.md#external-endpoints

lil mermaid diagram of implementation:
```mermaid
graph TD
    A[Prometheus] -->|Always Fires| B[Watchdog Alert]
    B -->|Every 60s| C[AlertManager]
    C -->|Webhook POST with Bearer Token| D[Gatus External Endpoint]
    D -->|Resets 30m Timer| E[Gatus Heartbeat Monitor]
    
    F[AlertManager Failure] -->|No Webhook Sent| G[30m Timer Expires]
    G -->|Triggers Alert| H[Pushover Notification]
    
    subgraph "Normal Operation"
        B
        C
        D
        E
    end
    
    subgraph "Failure Detection"
        F
        G
        H
    end
    
    style A fill:#e1f5fe
    style H fill:#ffebee
    style E fill:#e8f5e8
```