### PR TITLE
fix: handle rook-ceph 1.20 breaking changes

### DIFF
--- a/kubernetes/apps/rook-ceph/rook-ceph/csi/helmrelease.yaml
+++ b/kubernetes/apps/rook-ceph/rook-ceph/csi/helmrelease.yaml
@@ -1,0 +1,49 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/helm.toolkit.fluxcd.io/helmrelease_v2.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: ceph-csi-drivers
+spec:
+  interval: 1h
+  timeout: 15m
+  chart:
+    spec:
+      chart: ceph-csi-drivers
+      version: "1.0.1"
+      sourceRef:
+        kind: HelmRepository
+        name: ceph-csi-operator
+        namespace: rook-ceph
+  install:
+    remediation:
+      retries: -1
+  upgrade:
+    cleanupOnFail: true
+    remediation:
+      retries: 3
+  # Rook-recommended values — the chart fails on its own defaults.
+  # Driver name prefix MUST equal the rook operator namespace (rook-ceph)
+  values:
+    operatorConfig:
+      namespace: rook-ceph
+      driverSpecDefaults:
+        imageSet:
+          name: rook-csi-operator-image-set-configmap
+        nodePlugin:
+          priorityClassName: system-node-critical
+        controllerPlugin:
+          priorityClassName: system-cluster-critical
+    drivers:
+      rbd:
+        enabled: true
+        name: rook-ceph.rbd.csi.ceph.com
+      cephfs:
+        enabled: false
+        name: rook-ceph.cephfs.csi.ceph.com
+      nfs:
+        enabled: false
+        name: rook-ceph.nfs.csi.ceph.com
+      nvmeof:
+        enabled: false
+        name: rook-ceph.nvmeof.csi.ceph.com

--- a/kubernetes/apps/rook-ceph/rook-ceph/csi/helmrelease.yaml
+++ b/kubernetes/apps/rook-ceph/rook-ceph/csi/helmrelease.yaml
@@ -34,6 +34,7 @@ spec:
           priorityClassName: system-node-critical
         controllerPlugin:
           priorityClassName: system-cluster-critical
+          replicas: 2
     drivers:
       rbd:
         enabled: true

--- a/kubernetes/apps/rook-ceph/rook-ceph/csi/helmrepository.yaml
+++ b/kubernetes/apps/rook-ceph/rook-ceph/csi/helmrepository.yaml
@@ -1,0 +1,9 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/source.toolkit.fluxcd.io/helmrepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: HelmRepository
+metadata:
+  name: ceph-csi-operator
+spec:
+  interval: 1h
+  url: https://ceph.github.io/ceph-csi-operator

--- a/kubernetes/apps/rook-ceph/rook-ceph/ks.yaml
+++ b/kubernetes/apps/rook-ceph/rook-ceph/ks.yaml
@@ -26,7 +26,7 @@ spec:
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:
-  name: &app rook-ceph-cluster
+  name: &app ceph-csi-drivers
   namespace: &namespace rook-ceph
 spec:
   dependsOn:
@@ -35,7 +35,33 @@ spec:
   healthChecks:
     - apiVersion: helm.toolkit.fluxcd.io/v2
       kind: HelmRelease
-      name: rook-ceph-cluster
+      name: *app
+      namespace: *namespace
+  interval: 1h
+  path: ./kubernetes/apps/rook-ceph/rook-ceph/csi
+  prune: true
+  retryInterval: 2m
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  targetNamespace: *namespace
+  timeout: 5m
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app rook-ceph-cluster
+  namespace: &namespace rook-ceph
+spec:
+  dependsOn:
+    - name: ceph-csi-drivers
+      namespace: *namespace
+  healthChecks:
+    - apiVersion: helm.toolkit.fluxcd.io/v2
+      kind: HelmRelease
+      name: *app
       namespace: *namespace
   interval: 1h
   path: ./kubernetes/apps/rook-ceph/rook-ceph/cluster


### PR DESCRIPTION
## What

Fixes the CSI driver breakage introduced by the rook-ceph v1.19.5 → v1.20.1
upgrade (#1365) by adding the now-mandatory `ceph-csi-drivers` Helm chart.

## Why

Rook v1.20 stops deploying the Ceph-CSI drivers itself — driver lifecycle
(ServiceAccounts, RBAC, `Driver`/`OperatorConfig` CRs) moved to a standalone,
mandatory `ceph-csi-drivers` chart, and the ceph-csi-operator bumped to v1.0.1
(SA prefix `ceph-csi-` → `''`). PR #1365 bumped the operator + cluster charts
but never added the drivers chart, so the per-driver ServiceAccounts
(`ceph-csi-rbd-nodeplugin-sa`, etc.) were pruned and nothing recreated them.

Result: `rbd` CSI pods reference ServiceAccounts that no longer exist and fail
with `failed to get node "<node>" information: Unauthorized` (401 on a bound
token for a deleted SA). The nodeplugin DaemonSet rollout is wedged on
mbp-node-02, and the provisioner (ctrlplugin) is down — new PVC provisioning /
attach / resize is degraded cluster-wide. Ceph data plane itself is healthy
(HEALTH_OK, ceph v20.2.1), so no data impact.

Ref: https://rook.github.io/docs/rook/v1.20/Upgrade/rook-upgrade/
("This ceph-csi-drivers chart must be installed, otherwise the CSI driver
will be in a failed state due to missing service accounts.")

## Changes

- Add `kubernetes/apps/rook-ceph/rook-ceph/csi/`:
  - `HelmRepository` `ceph-csi-operator` (https://ceph.github.io/ceph-csi-operator)
  - `HelmRelease` `ceph-csi-drivers` (chart v1.0.1) with Rook-recommended values
    (driver name prefixed with the rook operator namespace; RBD only — CephFS/
    NFS/NVMeOF disabled to match our RBD-only topology; imageSet pinned to the
    operator-managed `rook-csi-operator-image-set-configmap`).
- Wire `ks.yaml`: new `ceph-csi-drivers` Kustomization (dependsOn `rook-ceph`),
  and repoint `rook-ceph-cluster` to dependsOn `ceph-csi-drivers`
  (enforces the required v1.20 apply order: rook-ceph → ceph-csi-drivers →
  rook-ceph-cluster).
- Harden `helm-repository-sync` workflow to tolerate net-new HelmRepositories
  that don't yet exist on the cluster.

## Validation

- flux-local `test` + `diff` pass; rendered diff confirms the missing SAs +
  RBAC are created and the `Driver` CR wires nodePlugin/controllerPlugin to them.
- Existing `Driver`/`OperatorConfig` CRs already carry
  `meta.helm.sh/release-name: ceph-csi-drivers` → adopted by Helm, no conflict.

## Post-merge

1. `flux reconcile kustomization ceph-csi-drivers --with-source`
2. Confirm SAs exist: `kubectl -n rook-ceph get sa | grep csi-ceph-com`
3. Unstick the wedged nodeplugin rollout (maxUnavailable deadlock):
   `kubectl -n rook-ceph delete pod -l app=rook-ceph.rbd.csi.ceph.com-nodeplugin --field-selector status.phase!=Running`
4. Verify all 5 nodeplugins + ctrlplugin Ready, and `ceph -s` HEALTH_OK.

## Follow-up (separate PR)

- Prune the now no-op `csi:` block from the rook-ceph operator HelmRelease
  (CSI config moved to the drivers chart in v1.20).